### PR TITLE
You cannot change the Table name other than "Extract".

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ tableDef.addColumn('Price', enums.type('Double'));
 extract = new tableau.dataExtract('/path/to/your.tde');
 
 // Add your table definition to the extract.
-table = extract.addTable('extract', tableDef);
+table = extract.addTable('Extract', tableDef);
 
 // Create a row of data.
 row = tableau.tableRow(tableDef);

--- a/src/TableauException.h
+++ b/src/TableauException.h
@@ -1,0 +1,26 @@
+#ifndef EXCEPTION_H
+#define EXCEPTION_H
+
+#include <iostream>
+#include <node.h>
+#include <node_object_wrap.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <TableauExtract/TableauExtract_cpp.h>
+#else
+#include "TableauExtract_cpp.h"
+#endif
+
+#define THROW_TABLEAU_EXCEPTION( exc ) \
+  do { \
+    Isolate* isolate = args.GetIsolate(); \
+    \
+    wstring wErrorMessage = exc.GetMessage(); \
+    string errorMessage(wErrorMessage.begin(), wErrorMessage.end()); \
+    \
+    isolate->ThrowException(String::NewFromUtf8(isolate, errorMessage.c_str())); \
+    return; \
+  } while (0) 
+
+
+#endif

--- a/src/TableauExtract.cc
+++ b/src/TableauExtract.cc
@@ -1,5 +1,6 @@
 #include "TableauExtract.h"
 #include "TableauTable.h"
+#include "TableauException.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TableauExtract/TableauExtract_cpp.h>
@@ -104,7 +105,11 @@ void Extract::HasTable(const FunctionCallbackInfo<Value>& args) {
 }
 
 void Extract::AddTable(const FunctionCallbackInfo<Value>& args) {
-  NodeTde::Table::NewInstanceFromDefinition(args);
+  try {
+    NodeTde::Table::NewInstanceFromDefinition(args);
+  } catch (const Tableau::TableauException& e) {
+    THROW_TABLEAU_EXCEPTION(e);
+  }
 }
 
 void Extract::OpenTable(const FunctionCallbackInfo<Value>& args) {

--- a/src/TableauServerConnection.cc
+++ b/src/TableauServerConnection.cc
@@ -1,4 +1,5 @@
 #include "TableauServerConnection.h"
+#include "TableauException.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TableauServer/TableauServer_cpp.h>
@@ -107,13 +108,7 @@ void ServerConnection::Connect(const FunctionCallbackInfo<Value>& args) {
     obj->nativeServerConnection_->Connect(wHost, wUser, wPass, wSiteId);
   }
   catch (const Tableau::TableauException& e) {
-    Isolate* isolate = args.GetIsolate();
-
-    wstring wErrorMessage = e.GetMessage();
-    string errorMessage(wErrorMessage.begin(), wErrorMessage.end());
-
-    isolate->ThrowException(String::NewFromUtf8(isolate, errorMessage.c_str()));
-    return;
+    THROW_TABLEAU_EXCEPTION(e); 
   }
 }
 
@@ -146,13 +141,7 @@ void ServerConnection::PublishExtract(const FunctionCallbackInfo<Value>& args) {
     obj->nativeServerConnection_->PublishExtract(wPath, wProjectName, wDataSourceName, overwrite);
   }
   catch (const Tableau::TableauException& e) {
-    Isolate* isolate = args.GetIsolate();
-
-    wstring wErrorMessage = e.GetMessage();
-    string errorMessage(wErrorMessage.begin(), wErrorMessage.end());
-
-    isolate->ThrowException(String::NewFromUtf8(isolate, errorMessage.c_str()));
-    return;
+    THROW_TABLEAU_EXCEPTION(e); 
   }
 }
 


### PR DESCRIPTION
Tableau API is so dumb that if you are using Table name other that `Extract` it will throw an exception. Since you do not manage exceptions other than in the server part it just crashes the complete v8 engine if you try something else.

When I have time I will add some exception handling to `TableauExtract.cc` but fixing the docs would be the very first step