### PR TITLE
Better C++ exception handling

### DIFF
--- a/src/TableauException.h
+++ b/src/TableauException.h
@@ -5,12 +5,6 @@
 #include <node.h>
 #include <node_object_wrap.h>
 
-#if defined(__APPLE__) && defined(__MACH__)
-#include <TableauExtract/TableauExtract_cpp.h>
-#else
-#include "TableauExtract_cpp.h"
-#endif
-
 #define THROW_TABLEAU_EXCEPTION( exc ) \
   do { \
     Isolate* isolate = args.GetIsolate(); \
@@ -21,6 +15,5 @@
     isolate->ThrowException(String::NewFromUtf8(isolate, errorMessage.c_str())); \
     return; \
   } while (0) 
-
 
 #endif

--- a/src/TableauException.h
+++ b/src/TableauException.h
@@ -1,0 +1,26 @@
+#ifndef EXCEPTION_H
+#define EXCEPTION_H
+
+#include <iostream>
+#include <node.h>
+#include <node_object_wrap.h>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <TableauExtract/TableauExtract_cpp.h>
+#else
+#include "TableauExtract_cpp.h"
+#endif
+
+#define THROW_TABLEAU_EXCEPTION( exc ) \
+  do { \
+    Isolate* isolate = args.GetIsolate(); \
+    \
+    wstring wErrorMessage = exc.GetMessage(); \
+    string errorMessage(wErrorMessage.begin(), wErrorMessage.end()); \
+    \
+    isolate->ThrowException(String::NewFromUtf8(isolate, errorMessage.c_str())); \
+    return; \
+  } while (0) 
+
+
+#endif

--- a/src/TableauExtract.cc
+++ b/src/TableauExtract.cc
@@ -119,7 +119,12 @@ void Extract::AddTable(const FunctionCallbackInfo<Value>& args) {
 }
 
 void Extract::OpenTable(const FunctionCallbackInfo<Value>& args) {
-  NodeTde::Table::NewInstance(args);
+  try {
+    NodeTde::Table::NewInstance(args);
+  }
+  catch (const Tableau::TableauException& e) {
+    THROW_TABLEAU_EXCEPTION(e);
+  }
 }
 
 Tableau::Extract* Extract::GetExtract() {

--- a/src/TableauExtract.cc
+++ b/src/TableauExtract.cc
@@ -70,9 +70,14 @@ void Extract::New(const FunctionCallbackInfo<Value>& args) {
     std::copy(path.begin(), path.end(), wpath.begin());
     //nativeExtract extract(wpath);
 
-    Extract* obj = new Extract(wpath);
-    obj->Wrap(args.This());
-    args.GetReturnValue().Set(args.This());
+    try {
+      Extract* obj = new Extract(wpath);
+      obj->Wrap(args.This());
+      args.GetReturnValue().Set(args.This());
+    }
+     catch (const Tableau::TableauException& e) {
+      THROW_TABLEAU_EXCEPTION(e);
+    }
   }
   // Invoked as plain function `Extract(...)`, turn into construct call.
   else {
@@ -107,7 +112,8 @@ void Extract::HasTable(const FunctionCallbackInfo<Value>& args) {
 void Extract::AddTable(const FunctionCallbackInfo<Value>& args) {
   try {
     NodeTde::Table::NewInstanceFromDefinition(args);
-  } catch (const Tableau::TableauException& e) {
+  }
+  catch (const Tableau::TableauException& e) {
     THROW_TABLEAU_EXCEPTION(e);
   }
 }

--- a/src/TableauExtract.cc
+++ b/src/TableauExtract.cc
@@ -1,5 +1,6 @@
 #include "TableauExtract.h"
 #include "TableauTable.h"
+#include "TableauException.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TableauExtract/TableauExtract_cpp.h>
@@ -104,7 +105,11 @@ void Extract::HasTable(const FunctionCallbackInfo<Value>& args) {
 }
 
 void Extract::AddTable(const FunctionCallbackInfo<Value>& args) {
-  NodeTde::Table::NewInstanceFromDefinition(args);
+  try {
+    NodeTde::Table::NewInstanceFromDefinition(args);
+  } catch (const Tableau::TableauException& e) {
+    THROW_TABLEAU_EXCEPTION(e);
+  }
 }
 
 void Extract::OpenTable(const FunctionCallbackInfo<Value>& args) {

--- a/src/TableauRow.cc
+++ b/src/TableauRow.cc
@@ -1,5 +1,6 @@
 #include "TableauRow.h"
 #include "TableauTableDefinition.h"
+#include "TableauException.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TableauExtract/TableauExtract_cpp.h>
@@ -158,7 +159,12 @@ void Row::SetDate(const FunctionCallbackInfo<Value>& args) {
   int day(args[3]->IntegerValue());
 
   Row* obj = ObjectWrap::Unwrap<Row>(args.Holder());
-  obj->nativeRow_->SetDate(columnNumber, year, month, day);
+  try {
+    obj->nativeRow_->SetDate(columnNumber, year, month, day);
+  }
+  catch (const Tableau::TableauException& e) {
+    THROW_TABLEAU_EXCEPTION(e);
+  }
 }
 
 void Row::SetDateTime(const FunctionCallbackInfo<Value>& args) {
@@ -172,7 +178,12 @@ void Row::SetDateTime(const FunctionCallbackInfo<Value>& args) {
   int frac(args[7]->IntegerValue());
 
   Row* obj = ObjectWrap::Unwrap<Row>(args.Holder());
-  obj->nativeRow_->SetDateTime(columnNumber, year, month, day, hour, min, sec, frac);
+  try {
+    obj->nativeRow_->SetDateTime(columnNumber, year, month, day, hour, min, sec, frac);
+  }
+  catch (const Tableau::TableauException& e) {
+    THROW_TABLEAU_EXCEPTION(e);
+  }
 }
 
 void Row::SetDuration(const FunctionCallbackInfo<Value>& args) {

--- a/src/TableauServerConnection.cc
+++ b/src/TableauServerConnection.cc
@@ -1,4 +1,5 @@
 #include "TableauServerConnection.h"
+#include "TableauException.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TableauServer/TableauServer_cpp.h>
@@ -107,13 +108,7 @@ void ServerConnection::Connect(const FunctionCallbackInfo<Value>& args) {
     obj->nativeServerConnection_->Connect(wHost, wUser, wPass, wSiteId);
   }
   catch (const Tableau::TableauException& e) {
-    Isolate* isolate = args.GetIsolate();
-
-    wstring wErrorMessage = e.GetMessage();
-    string errorMessage(wErrorMessage.begin(), wErrorMessage.end());
-
-    isolate->ThrowException(String::NewFromUtf8(isolate, errorMessage.c_str()));
-    return;
+    THROW_TABLEAU_EXCEPTION(e); 
   }
 }
 
@@ -146,13 +141,7 @@ void ServerConnection::PublishExtract(const FunctionCallbackInfo<Value>& args) {
     obj->nativeServerConnection_->PublishExtract(wPath, wProjectName, wDataSourceName, overwrite);
   }
   catch (const Tableau::TableauException& e) {
-    Isolate* isolate = args.GetIsolate();
-
-    wstring wErrorMessage = e.GetMessage();
-    string errorMessage(wErrorMessage.begin(), wErrorMessage.end());
-
-    isolate->ThrowException(String::NewFromUtf8(isolate, errorMessage.c_str()));
-    return;
+    THROW_TABLEAU_EXCEPTION(e); 
   }
 }
 

--- a/src/TableauTable.cc
+++ b/src/TableauTable.cc
@@ -91,6 +91,12 @@ void Table::NewInstanceFromDefinition(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
+  // Check for table definition argument.
+  if (!args[1]->IsObject()) {
+    isolate->ThrowException(String::NewFromUtf8(isolate, "You must provide a table definition when adding a table."));
+    return;
+  }
+
   Local<ObjectTemplate> tpl = ObjectTemplate::New(isolate);
   tpl->SetInternalFieldCount(1);
   Local<Object> instance = tpl->NewInstance();

--- a/src/TableauTable.cc
+++ b/src/TableauTable.cc
@@ -2,6 +2,7 @@
 #include "TableauExtract.h"
 #include "TableauTableDefinition.h"
 #include "TableauRow.h"
+#include "TableauException.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TableauExtract/TableauExtract_cpp.h>
@@ -83,6 +84,12 @@ void Table::NewInstance(const FunctionCallbackInfo<Value>& args) {
 
 void Table::NewInstanceFromDefinition(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+
+  // Check for a table name argument.
+  if (!args[0]->IsString()) {
+    isolate->ThrowException(String::NewFromUtf8(isolate, "You must provide a table name of 'Extract' when adding a table."));
+    return;
+  }
 
   Local<ObjectTemplate> tpl = ObjectTemplate::New(isolate);
   tpl->SetInternalFieldCount(1);

--- a/src/TableauTableDefinition.cc
+++ b/src/TableauTableDefinition.cc
@@ -163,8 +163,13 @@ void TableDefinition::AddColumnWithCollation(const FunctionCallbackInfo<Value>& 
   int collationInt(args[2]->IntegerValue());
   Tableau::Collation collation = static_cast<Tableau::Collation>(collationInt);
 
-  TableDefinition* obj = ObjectWrap::Unwrap<TableDefinition>(args.Holder());
-  obj->nativeTableDefinition_->AddColumnWithCollation(column, type, collation);
+  try {
+    TableDefinition* obj = ObjectWrap::Unwrap<TableDefinition>(args.Holder());
+    obj->nativeTableDefinition_->AddColumnWithCollation(column, type, collation);
+  }
+  catch (const Tableau::TableauException& e) {
+    THROW_TABLEAU_EXCEPTION(e);
+  }
 }
 
 void TableDefinition::GetColumnCount(const FunctionCallbackInfo<Value>& args) {

--- a/src/TableauTableDefinition.cc
+++ b/src/TableauTableDefinition.cc
@@ -1,5 +1,6 @@
 #include "TableauTableDefinition.h"
 #include "TableauTable.h"
+#include "TableauException.h"
 
 #if defined(__APPLE__) && defined(__MACH__)
 #include <TableauExtract/TableauExtract_cpp.h>
@@ -141,8 +142,13 @@ void TableDefinition::AddColumn(const FunctionCallbackInfo<Value>& args) {
   int typeInt(args[1]->IntegerValue());
   Tableau::Type type = static_cast<Tableau::Type>(typeInt);
 
-  TableDefinition* obj = ObjectWrap::Unwrap<TableDefinition>(args.Holder());
-  obj->nativeTableDefinition_->AddColumn(column, type);
+  try {
+    TableDefinition* obj = ObjectWrap::Unwrap<TableDefinition>(args.Holder());
+    obj->nativeTableDefinition_->AddColumn(column, type);
+  }
+  catch (const Tableau::TableauException& e) {
+    THROW_TABLEAU_EXCEPTION(e);
+  }
 }
 
 void TableDefinition::AddColumnWithCollation(const FunctionCallbackInfo<Value>& args) {

--- a/test/extract.js
+++ b/test/extract.js
@@ -87,6 +87,16 @@ describe('extract', function () {
     return extract.addTable('Extract', tableDef).should.have.property('insert');
   });
 
+  it('throws error when opening non-existent table on extract', function () {
+    // Create an extract.
+    expectedPath = targetDir + '/mocha-404-table-not-found.tde';
+    extract = tableau.dataExtract(expectedPath);
+
+    // Attempt to open a table that does not exist.
+    expect(extract.openTable.bind(extract, 'UnrealTable'))
+      .to.throw();
+  });
+
   it('opens existing table on extract', function () {
     // Create an extract.
     expectedPath = targetDir + '/mocha-open-table.tde';

--- a/test/extract.js
+++ b/test/extract.js
@@ -25,6 +25,14 @@ describe('extract', function () {
     process.env['TAB_SDK_LOGDIR'] = targetDir;
   });
 
+  it('throws error when opening extract with invalid name', function () {
+    expectedPath = targetDir + 'invalid-name';
+
+    // Attempt to open an extract with an invalid name (doesn't end in ".tde").
+    expect(tableau.dataExtract.bind(tableau, expectedPath))
+      .to.throw();
+  });
+
   it('creates an extract file', function () {
     expectedPath = targetDir + '/mocha-create.tde';
     extract = tableau.dataExtract(expectedPath);
@@ -107,7 +115,10 @@ describe('extract', function () {
 
     // Delete any TDEs that have been generated.
     if (expectedPath) {
-      fs.unlinkSync(expectedPath);
+      try {
+        fs.unlinkSync(expectedPath);
+      }
+      catch (e) {}
       expectedPath = null;
     }
   });

--- a/test/extract.js
+++ b/test/extract.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var chai = require('chai'),
+    expect = chai.expect,
     fs = require('fs');
 
 chai.use(require('chai-fs'));
@@ -50,6 +51,20 @@ describe('extract', function () {
     extract = tableau.dataExtract(expectedPath);
 
     return extract.hasTable('Extract').should.be.false;
+  });
+
+  it('throws error when adding invalid table name', function () {
+    // Create an extract.
+    expectedPath = targetDir + '/mocha-add-invalid-table.tde';
+    extract = tableau.dataExtract(expectedPath);
+
+    // Create a table definition.
+    tableDef = tableau.tableDefinition();
+    tableDef.addColumn('Column', tableau.enums.type('Boolean'));
+
+    // Attempt to add a table with a name other than Extract.
+    expect(extract.addTable.bind(extract, 'Invalid', tableDef))
+      .to.throw();
   });
 
   it('adds table to extract', function () {

--- a/test/table.js
+++ b/test/table.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var chai = require('chai'),
+    expect = chai.expect,
     fs = require('fs');
 
 chai.use(require('chai-fs'));
@@ -32,6 +33,13 @@ describe('table', function () {
     tableDef.setDefaultCollation(enums.collation('en_US'));
     tableDef.addColumnWithCollation('FirstColumn', enums.type('Boolean'), enums.collation('ja'));
     tableDef.addColumnWithCollation('SecondColumn', enums.type('CharString'), enums.collation('en_GB'));
+  });
+
+  it('throws error when adding table without name', function () {
+    // Attempt to add a table with no name.
+    expect(extract.addTable.bind(extract))
+      // Note: this exception is defined by us (not Tableau SDK).
+      .to.throw('You must provide a table name');
   });
 
   it('gets table definition from added table', function () {

--- a/test/table.js
+++ b/test/table.js
@@ -42,6 +42,13 @@ describe('table', function () {
       .to.throw('You must provide a table name');
   });
 
+  it('throws error when adding table without a definition', function () {
+    // Attempt to add a table with no name.
+    expect(extract.addTable.bind(extract, 'Extract'))
+      // Note: this exception is defined by us (not Tableau SDK).
+      .to.throw('You must provide a table definition');
+  });
+
   it('gets table definition from added table', function () {
     var returnedTableDef;
 

--- a/test/tableDefinition.js
+++ b/test/tableDefinition.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var chai = require('chai'),
+    expect = chai.expect,
     fs = require('fs');
 
 chai.use(require('chai-fs'));
@@ -38,6 +39,23 @@ describe('tableDefinition', function () {
     tableDef = tableau.tableDefinition();
 
     return tableDef.getColumnCount().should.equal(0);
+  });
+
+  it('throws error when adding column with invalid type', function () {
+    tableDef = tableau.tableDefinition();
+
+    // Attempt to add a column with an invalid type.
+    expect(tableDef.addColumn.bind(tableDef, 'Price', 'InvalidType'))
+      .to.throw();
+  });
+
+  it('throws error when adding column with duplicate name', function () {
+    tableDef = tableau.tableDefinition();
+    tableDef.addColumn('Price', enums.type('Double'));
+
+    // Attempt to add a column with the same name.
+    expect(tableDef.addColumn.bind(tableDef, 'Price', enums.type('Double')))
+      .to.throw();
   });
 
   it('adds column', function () {

--- a/test/tableDefinition.js
+++ b/test/tableDefinition.js
@@ -90,6 +90,23 @@ describe('tableDefinition', function () {
     return tableDef.getColumnCount().should.equal(1);
   });
 
+  it('throws error when adding column with collation with invalid type', function () {
+    tableDef = tableau.tableDefinition();
+
+    // Attempt to add a column with collation with an invalid type.
+    expect(tableDef.addColumnWithCollation.bind(tableDef, 'Price', 'InvalidType'))
+      .to.throw();
+  });
+
+  it('throws error when adding column with duplicate name', function () {
+    tableDef = tableau.tableDefinition();
+    tableDef.addColumnWithCollation('Price', enums.type('Double'), enums.collation('ja'));
+
+    // Attempt to add a column with collation with the same name.
+    expect(tableDef.addColumnWithCollation.bind(tableDef, 'Price', enums.type('Double'),  enums.collation('ja')))
+      .to.throw();
+  });
+
   it('gets column collation', function () {
     var expectedColumnCollation = enums.collation('ja');
 

--- a/test/tableRow.js
+++ b/test/tableRow.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var chai = require('chai'),
+    expect = chai.expect,
     fs = require('fs');
 
 chai.use(require('chai-fs'));
@@ -71,11 +72,23 @@ describe('tableRow', function () {
     tableRow.setDate(3, 3000, 12, 31);
   });
 
+  it('throws error when inserting invalid date values', function () {
+    tableRow = tableau.tableRow(tableDef);
+    expect(tableRow.setDate.bind(tableau, 3, 2016, 0, 24))
+      .to.throw();
+  });
+
   it('sets date/time values', function () {
     tableRow = tableau.tableRow(tableDef);
     tableRow.setDateTime(4, 2016, 4, 24, 16, 44, 23, 0);
     tableRow.setDateTime(4, 1959, 3, 27, 1, 0, 0, 0, 0);
     tableRow.setDateTime(4, 3000, 12, 31, 20, 9, 14, 100);
+  });
+
+  it('throws error when inserting invalid date/time values', function () {
+    tableRow = tableau.tableRow(tableDef);
+    expect(tableRow.setDateTime.bind(tableau, 3, 2016, 0, 24, 16, 44, 23, 0))
+      .to.throw();
   });
 
   it('sets duration values', function () {


### PR DESCRIPTION
Node itself shouldn't die when the native SDK throws an exception. We should just pass the exceptions on in JS-land.