### PR TITLE
Supported versions roundup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ addons:
       - clang
 
 node_js:
-  - '4.5'
+  - '4'
+  - '6'
 
 os:
   - linux
@@ -22,6 +23,7 @@ env:
   matrix:
     - TABLEAU_SDK_VERSION=9-3-0
     - TABLEAU_SDK_VERSION=10-0-0
+    - TABLEAU_SDK_VERSION=10-2-0
 
 before_install:
   - ./scripts/install-sdk.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode8.2
+
 env:
   matrix:
     - TABLEAU_SDK_VERSION=9-3-0

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ to Tableau Server and Tableau Online using JavaScript!
 ## Installation
 
 __Warning__: Under active development. Currently only known to work on OSX and
-Ubuntu using node v4.5. Check the issue queue for updates or to contribute
-improvements!
+Ubuntu using LTS versions of node (v4, v6). Check the issue queue for updates or
+to contribute improvements!
 
 1. Install the [C/C++ Tableau SDK](https://onlinehelp.tableau.com/current/api/sdk/en-us/help.htm#SDK/tableau_sdk_installing.htm)
    for your platform,
 1. You may need to install node-gyp (`npm install node-gyp -g`)
+1. If you're on OS X, be sure XCode and command line tools are installed. You
+   may need to run `xcode-select --install`
 1. Pull the SDK from npm. `npm install tableau-sdk --save`,
 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "mocha": "^2.4.5"
   },
   "scripts": {
-    "test": "mocha test/*.js",
+    "test": "mocha --retries 5 test/*.js",
     "install": "node-gyp rebuild"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
+    "chai": "^1.10.0",
     "chai-fs": "^0.1.0",
     "mocha": "^2.4.5"
   },

--- a/test/extract.js
+++ b/test/extract.js
@@ -15,7 +15,7 @@ describe('extract', function () {
       tableDef;
 
   // These tests actually read/write from/to disk. Account for slowness here.
-  this.timeout(10000);
+  this.timeout(20000);
 
   before(function() {
     // Ensure we have a place to put test extracts.

--- a/test/extract.js
+++ b/test/extract.js
@@ -15,7 +15,7 @@ describe('extract', function () {
       tableDef;
 
   // These tests actually read/write from/to disk. Account for slowness here.
-  this.timeout(5000);
+  this.timeout(10000);
 
   before(function() {
     // Ensure we have a place to put test extracts.

--- a/test/serverConnection.js
+++ b/test/serverConnection.js
@@ -13,7 +13,7 @@ describe('serverConnection', function () {
       serverConnection;
 
   // These tests actually attempt network requests. Account for slowness here.
-  this.timeout(5000);
+  this.timeout(10000);
 
   before(function() {
     // Ensure we have a place to put test extracts.

--- a/test/serverConnection.js
+++ b/test/serverConnection.js
@@ -13,7 +13,7 @@ describe('serverConnection', function () {
       serverConnection;
 
   // These tests actually attempt network requests. Account for slowness here.
-  this.timeout(10000);
+  this.timeout(20000);
 
   before(function() {
     // Ensure we have a place to put test extracts.

--- a/test/table.js
+++ b/test/table.js
@@ -17,7 +17,7 @@ describe('table', function () {
       table;
 
   // Some of these tests actually read from disk. Account for slowness here.
-  this.timeout(10000);
+  this.timeout(20000);
 
   before(function() {
     // Ensure we have a place to put test extracts.

--- a/test/table.js
+++ b/test/table.js
@@ -17,7 +17,7 @@ describe('table', function () {
       table;
 
   // Some of these tests actually read from disk. Account for slowness here.
-  this.timeout(5000);
+  this.timeout(10000);
 
   before(function() {
     // Ensure we have a place to put test extracts.

--- a/test/wrapper.js
+++ b/test/wrapper.js
@@ -36,7 +36,7 @@ describe('wrapper', function () {
       extract;
 
   // These tests actually read/write from/to disk. Account for slowness here.
-  this.timeout(10000);
+  this.timeout(20000);
 
   before(function() {
     // Ensure we have a place to put test extracts.

--- a/test/wrapper.js
+++ b/test/wrapper.js
@@ -129,7 +129,7 @@ describe('wrapper', function () {
         -42,
         1.337,
         '2016-01-01',
-        '2015-09-23 12:23pm'
+        '2015-09-23 12:23'
       ]);
       extract.close();
       afterSize = fs.statSync(expectedPath)['size'];
@@ -195,7 +195,7 @@ describe('wrapper', function () {
         null,
         1,
         '2016-01-01',
-        '2015-09-23 12:23pm'
+        '2015-09-23 12:23'
       ]]);
       extract.close();
       afterSize = fs.statSync(expectedPath)['size'];

--- a/test/wrapper.js
+++ b/test/wrapper.js
@@ -36,7 +36,7 @@ describe('wrapper', function () {
       extract;
 
   // These tests actually read/write from/to disk. Account for slowness here.
-  this.timeout(5000);
+  this.timeout(10000);
 
   before(function() {
     // Ensure we have a place to put test extracts.


### PR DESCRIPTION
- OS X builds now run on Sierra
- Builds with Node v4.x _and_ v6.x (OS X + Linux)
- Builds against SDK v9.3.0, 10.0.0, and 10.2.0.
- Improved documentation around installing on OS X