### PR TITLE
Add spatial column types from the 10.2 SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ osx_image: xcode8.2
 
 env:
   matrix:
-    - TABLEAU_SDK_VERSION=9-3-0
-    - TABLEAU_SDK_VERSION=10-0-0
     - TABLEAU_SDK_VERSION=10-2-0
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ to contribute improvements!
 
 ## Usage
 
-Check [the examples folder](/tableau-mkt/node-tableau-sdk/tree/master/examples)
+Check [the examples folder](https://github.com/tableau-mkt/node-tableau-sdk/tree/master/examples)
 for sample usage, or see some examples below.
 
 For simplicity, this API borrows the [TableInfo](https://tableau.github.io/webdataconnector/ref/api_ref.html#webdataconnectorapi.tableinfo-1)
@@ -129,5 +129,5 @@ tableau.serverConnection;
 tableau.enums;
 ```
 
-See [advanced examples](/tableau-mkt/node-tableau-sdk/tree/master/examples/advanced)
+See [advanced examples](https://github.com/tableau-mkt/node-tableau-sdk/tree/master/examples/advanced)
 for more details. You may also wish to refer to the [C++ API reference docs](https://onlinehelp.tableau.com/current/api/sdk/en-us/SDK/C++/html/index.html).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ for sample usage, or see some examples below.
 
 For simplicity, this API borrows the [TableInfo](https://tableau.github.io/webdataconnector/ref/api_ref.html#webdataconnectorapi.tableinfo-1)
 and [ColumnInfo](https://tableau.github.io/webdataconnector/ref/api_ref.html#webdataconnectorapi.columninfo)
-data structures from the Tableau Web Data Connector API.
+data structures from the Tableau Web Data Connector API. In addition to the data
+types supported by the WDC API, you may specify a column with `dataType` set to
+`spatial` for your spatial data needs.
 
 ### Create an extract and add data
 ```javascript

--- a/enums.js
+++ b/enums.js
@@ -55,7 +55,8 @@ var _ = require('underscore'),
       13: 'DateTime',
       14: 'Duration',
       15: 'CharString',
-      16: 'UnicodeString'
+      16: 'UnicodeString',
+      17: 'Spatial'
     },
     setMethod: {
       7: 'setLongInteger',
@@ -65,7 +66,8 @@ var _ = require('underscore'),
       13: 'setDateTime',
       14: 'setDuration',
       15: 'setCharString',
-      16: 'setUnicodeString'
+      16: 'setUnicodeString',
+      17: 'setSpatial'
     },
     wdcType: {
       'Duration': 'int',
@@ -75,7 +77,8 @@ var _ = require('underscore'),
       'Date': 'date',
       'DateTime': 'datetime',
       'UnicodeString': 'string',
-      'CharString': 'string'
+      'CharString': 'string',
+      'Spatial': 'spatial'
     }
   },
   smune = {

--- a/examples/advanced/makeOrder.js
+++ b/examples/advanced/makeOrder.js
@@ -18,6 +18,7 @@ var makeTableDefinition = function() {
   def.addColumn('Taxed', enums.type('Boolean'));
   def.addColumn('Expiration Date', enums.type('Date'));
   def.addColumnWithCollation('Produkt', enums.type('CharString'), enums.collation('de'));
+  def.addColumn('Destination', enums.type('Spatial'));
   return def;
 };
 
@@ -37,7 +38,7 @@ var printTableDefinition = function(def) {
       enums.collationName(def.getColumnCollation(i))
     );
   }
-}
+};
 
 /**
  * Insert a few rows of data.
@@ -54,13 +55,14 @@ var insertData = function(table) {
   row.setDouble(3, 1.08); // Price
   row.setDate(6, 2029, 1, 1); // Expiration Date
   row.setCharString(7, 'Böhnen'); // Produkt
+  raw.setSpatial(8, 'POINT (30 10)'); // Destination
 
   for (i = 0; i < 10; i++) {
     row.setInteger(4, i * 10); // Quantity
     row.setBoolean(5, i % 2 === 1); // Taxed
     table.insert(row);
   }
-}
+};
 
 var extract = new tableau.dataExtract('order-js.tde'),
     table,

--- a/examples/makeOrder.js
+++ b/examples/makeOrder.js
@@ -27,6 +27,9 @@ tableDefinition = {
   }, {
     id: 'Expiration Date',
     dataType: 'date'
+  }, {
+    id: 'Destination',
+    dataType: 'spatial'
   }]
 };
 
@@ -44,7 +47,8 @@ for (i = 0; i < 10; i++) {
     Price: 1.08,
     Quantity: i * 10,
     Taxed: i % 2 === 1,
-    'Expiration Date': '2029-01-01'
+    'Expiration Date': '2029-01-01',
+    Destination: 'POINT (30 10)'
   });
 }
 

--- a/scripts/install-sdk.sh
+++ b/scripts/install-sdk.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LOCAL_SDK_VERSION=${TABLEAU_SDK_VERSION:-10-0-0}
+LOCAL_SDK_VERSION=${TABLEAU_SDK_VERSION:-10-2-0}
 
 # Install the SDK for linux
 if [ $TRAVIS_OS_NAME == 'linux' ]; then

--- a/src/TableauRow.cc
+++ b/src/TableauRow.cc
@@ -57,6 +57,7 @@ void Row::Init(Local<Object> exports) {
   NODE_SET_PROTOTYPE_METHOD(tpl, "setDate", SetDate);
   NODE_SET_PROTOTYPE_METHOD(tpl, "setDateTime", SetDateTime);
   NODE_SET_PROTOTYPE_METHOD(tpl, "setDuration", SetDuration);
+  NODE_SET_PROTOTYPE_METHOD(tpl, "setSpatial", SetSpatial);
 
   constructor.Reset(isolate, tpl->GetFunction());
   exports->Set(String::NewFromUtf8(isolate, "Row"), tpl->GetFunction());
@@ -196,6 +197,20 @@ void Row::SetDuration(const FunctionCallbackInfo<Value>& args) {
 
   Row* obj = ObjectWrap::Unwrap<Row>(args.Holder());
   obj->nativeRow_->SetDuration(columnNumber, day, hour, min, sec, frac);
+}
+
+void Row::SetSpatial(const FunctionCallbackInfo<Value>& args) {
+  int columnNumber(args[0]->IntegerValue());
+  String::Utf8Value v8String(args[1]->ToString());
+  string stringValue = string(*v8String);
+
+  Row* obj = ObjectWrap::Unwrap<Row>(args.Holder());
+  try {
+    obj->nativeRow_->SetSpatial(columnNumber, stringValue);
+  }
+  catch (const Tableau::TableauException& e) {
+    THROW_TABLEAU_EXCEPTION(e);
+  }
 }
 
 }

--- a/src/TableauRow.h
+++ b/src/TableauRow.h
@@ -34,6 +34,7 @@ class Row : public node::ObjectWrap {
   static void SetDate(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetDateTime(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetDuration(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetSpatial(const v8::FunctionCallbackInfo<v8::Value>& args);
   static v8::Persistent<v8::Function> constructor;
 
   Tableau::Row* nativeRow_;

--- a/test/tableRow.js
+++ b/test/tableRow.js
@@ -25,6 +25,7 @@ describe('tableRow', function () {
     tableDef.addColumn('DurationColumn', enums.type('Duration'));
     tableDef.addColumn('CharStringColumn', enums.type('CharString'));
     tableDef.addColumn('UnicodeStringColumn', enums.type('UnicodeString'));
+    tableDef.addColumn('SpatialColumn', enums.type('Spatial'));
   });
 
   it('creates a table row', function () {
@@ -112,6 +113,17 @@ describe('tableRow', function () {
     tableRow.setString(7, "A quoted string value");
     tableRow.setString(7, '1');
     tableRow.setString(7, false.toString());
+  });
+
+  it('sets spatial values', function () {
+    tableRow = tableau.tableRow(tableDef);
+    tableRow.setSpatial(8, 'POINT (30 10)');
+  });
+
+  it('throws error when inserting invalid spatial values', function () {
+    tableRow = tableau.tableRow(tableDef);
+    expect(tableRow.setSpatial.bind(tableau, 8, 'x,y,z'))
+      .to.throw();
   });
 
   afterEach(function () {

--- a/test/wrapper.js
+++ b/test/wrapper.js
@@ -30,6 +30,9 @@ describe('wrapper', function () {
         }, {
           id: 'testDateTime',
           dataType: 'datetime'
+        }, {
+          id: 'testSpatial',
+          dataType: 'spatial'
         }]
       },
       expectedPath,
@@ -129,7 +132,8 @@ describe('wrapper', function () {
         -42,
         1.337,
         '2016-01-01',
-        '2015-09-23 12:23'
+        '2015-09-23 12:23',
+        'LINESTRING(1 1, 3 3)'
       ]);
       extract.close();
       afterSize = fs.statSync(expectedPath)['size'];
@@ -154,7 +158,8 @@ describe('wrapper', function () {
         testDateTime: '20130208T080910,123',
         testDouble: 0,
         testInt: null,
-        testString: ''
+        testString: '',
+        testSpatial: 'POLYGON((-5 -5, -5 5, 5 5, 5 -5, -5 -5),(3 0, 6 0, 6 3, 3 3, 3 0))'
       });
       extract.close();
       afterSize = fs.statSync(expectedPath)['size'];
@@ -188,14 +193,16 @@ describe('wrapper', function () {
         testDateTime: '2013-02-08 09Z',
         testDouble: -0.0001,
         testInt: 123,
-        testString: 'C'
+        testString: 'C',
+        testSpatial: null
       }, [
         true,
         null,
         null,
         1,
         '2016-01-01',
-        '2015-09-23 12:23'
+        '2015-09-23 12:23',
+        'GEOMETRYCOLLECTION(LINESTRING(1 1, 3 5),POLYGON((-1 -1, -1 -5, -5 -5, -5 -1, -1 -1)))'
       ]]);
       extract.close();
       afterSize = fs.statSync(expectedPath)['size'];


### PR DESCRIPTION
Tableau 10.2 [added support for spatial data types](https://onlinehelp.tableau.com/current/api/sdk/en-us/help.htm#SDK/tableau_sdk_whats_new.html%3FTocPath%3D_____2).  We should bring support over to the node port.

### Usage
```javascript
var TDE = require('../index.js'),
    tableDefinition,
    extract;

// Define a table with a spatial column.
tableDefinition = {
  id: 'Extract',
  defaultAlias: 'Orders',
  columns: [
    {id: 'product', dataType: 'string'},
    {id: 'destination', dataType: 'spatial'}
  ]
}

// Create an extract and insert a row with spatial data.
extract = new TDE('order-js.tde', tableDefinition);
extract.insert({
  product: 'Beans',
  destination: 'POINT (30 10)'
});

extract.close();
```