### PR TITLE
Use Geometry instead of Spatial

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ for sample usage, or see some examples below.
 For simplicity, this API borrows the [TableInfo](https://tableau.github.io/webdataconnector/docs/api_ref.html#webdataconnectorapi.tableinfo-1)
 and [ColumnInfo](https://tableau.github.io/webdataconnector/docs/api_ref.html#webdataconnectorapi.columninfo)
 data structures from the Tableau Web Data Connector API. In addition to the data
-types supported by the WDC API, you may specify a column with `dataType` set to
-`spatial` for your spatial data needs.
+types supported by the WDC API. Note, while the underlying C++ Extract API uses
+`Spatial` to indicate spatial data types, the WDC API uses `geometry`. We follow
+that convention here too.
 
 ### Create an extract and add data
 ```javascript

--- a/enums.js
+++ b/enums.js
@@ -78,7 +78,7 @@ var _ = require('underscore'),
       'DateTime': 'datetime',
       'UnicodeString': 'string',
       'CharString': 'string',
-      'Spatial': 'spatial'
+      'Spatial': 'geometry'
     }
   },
   smune = {

--- a/examples/advanced/makeOrder.js
+++ b/examples/advanced/makeOrder.js
@@ -55,7 +55,7 @@ var insertData = function(table) {
   row.setDouble(3, 1.08); // Price
   row.setDate(6, 2029, 1, 1); // Expiration Date
   row.setCharString(7, 'Böhnen'); // Produkt
-  raw.setSpatial(8, 'POINT (30 10)'); // Destination
+  row.setSpatial(8, 'POINT (30 10)'); // Destination
 
   for (i = 0; i < 10; i++) {
     row.setInteger(4, i * 10); // Quantity

--- a/examples/makeOrder.js
+++ b/examples/makeOrder.js
@@ -29,7 +29,7 @@ tableDefinition = {
     dataType: 'date'
   }, {
     id: 'Destination',
-    dataType: 'spatial'
+    dataType: 'geometry'
   }]
 };
 

--- a/test/wrapper.js
+++ b/test/wrapper.js
@@ -32,7 +32,7 @@ describe('wrapper', function () {
           dataType: 'datetime'
         }, {
           id: 'testSpatial',
-          dataType: 'spatial'
+          dataType: 'geometry'
         }]
       },
       expectedPath,


### PR DESCRIPTION
Given we are releasing a `1.x` version (for 2018.2 + Hyper), let's use the WDC table definition for spatial data `geometry` instead of `spatial` as we originally went with.  No BC required for major version update.

Closes #14